### PR TITLE
Features up to 1.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,13 +36,19 @@ subprojects {
 	tasks.withType(Javadoc::class.java).configureEach {
 		isFailOnError = false
 		exclude("net/minecraftforge/mixin/**.java")
+		configurations.all {
+			if (isCanBeResolved) classpath += this@all
+		}
+		sourceSets.all {
+			source += allJava
+		}
 	}
 
 	tasks.withType(ProcessResources::class.java).configureEach {
-		inputs.property ("version", project.version)
+		inputs.property("version", project.version)
 
 		filesMatching("*.mod.json") {
-			expand ("version" to project.version)
+			expand("version" to project.version)
 		}
 	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 unimined = "1.4.0"
 spotless = "7.0.0.BETA1"
-fabric = "0.16.0"
+fabric = "0.16.2"
 
 [plugins]
 unimined = { id = "xyz.wagyourtail.unimined", version.ref = "unimined" }

--- a/minecraft/beta/1.7.3/build.gradle.kts
+++ b/minecraft/beta/1.7.3/build.gradle.kts
@@ -1,34 +1,34 @@
 @file:Suppress("UnstableApiUsage")
 
-import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
 import xyz.wagyourtail.unimined.api.minecraft.patch.fabric.LegacyFabricPatcher
+import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.util.capitalized
+import xyz.wagyourtail.unimined.util.sourceSets
+import xyz.wagyourtail.unimined.util.withSourceSet
 
 val main: SourceSet by sourceSets.named("main")
 val client: SourceSet by sourceSets.creating
 val server: SourceSet by sourceSets.creating
 
-val commonAW = File(projectDir, "src/main/resources/forge.common.accesswidener")
-val clientAW = File(projectDir, "src/client/resources/forge.client.accesswidener")
-val serverAW = File(projectDir, "src/server/resources/forge.server.accesswidener")
-
-tasks.build.configure {
-	dependsOn("remapClientJar", "remapServerJar")
-}
+val commonAW = main.resources.find {
+	it.name.equals("forge.common.accesswidener")
+}!!
 
 val fabricConfig: LegacyFabricPatcher.() -> Unit = {
 	loader(libs.versions.fabric.get())
 	customIntermediaries = true
-	prodNamespace("babricIntermediary")
+	prodNamespace("official")
 }
 
 unimined.minecraft {
 	version("b1.7.3")
 	side("server")
 	mappings {
+		calamus()
 		babricIntermediary()
 		retroMCP("b1.7")
 	}
-	legacyFabric {
+	ornitheFabric {
 		fabricConfig.invoke(this)
 		accessWidener(commonAW)
 	}
@@ -36,28 +36,47 @@ unimined.minecraft {
 	defaultRemapJar = false
 }
 
-val sidedMinecraftConfig: MinecraftConfig.(Boolean) -> Unit = { client ->
+unimined.minecraft(client, server) {
 	combineWith(main)
-	side(if (client) "client" else "server")
-	legacyFabric {
-		fabricConfig.invoke(this@legacyFabric)
+	side(sourceSet.name)
+	ornitheFabric {
+		fabricConfig.invoke(this@ornitheFabric)
 		accessWidener(
 			mergeAws(
 				File(sourceSet.output.resourcesDir, "forge.accesswidener"),
 				listOf(
-					commonAW, if (client) clientAW else serverAW
+					commonAW, sourceSet.resources.find {
+						it.name.equals("forge.${sourceSet.name}.accesswidener")
+					}!!
 				)
 			)
 		)
 	}
 	runs.off = false
 	defaultRemapJar = true
+	project.afterEvaluate {
+		val jarTaskName = "jar".withSourceSet(sourceSet)
+		val defaultJarTask = tasks.named(jarTaskName).get()
+		tasks.named("remap" + jarTaskName.capitalized(), RemapJarTask::class.java).configure {
+			archiveClassifier = "${sourceSet.name}-official"
+		}
+		val baseName = "remapJarTo".withSourceSet(sourceSet)
+		remap(defaultJarTask, "${baseName}Babric") {
+			archiveClassifier = "${sourceSet.name}-babric"
+			prodNamespace("babricIntermediary")
+		}
+		remap(defaultJarTask, "${baseName}Calamus") {
+			archiveClassifier = "${sourceSet.name}-calamus"
+			prodNamespace("calamus")
+		}
+	}
 }
 
-unimined.minecraft(client) {
-	sidedMinecraftConfig.invoke(this@minecraft, true)
-}
-
-unimined.minecraft(server) {
-	sidedMinecraftConfig.invoke(this@minecraft, false)
+tasks.build.configure {
+	for (set in arrayOf(client, server)) {
+		dependsOn(
+			"remapJarToBabric".withSourceSet(set),
+			"remapJarToCalamus".withSourceSet(set)
+		)
+	}
 }

--- a/minecraft/beta/1.7.3/src/client/java/net/minecraft/src/forge/MinecraftForgeClient.java
+++ b/minecraft/beta/1.7.3/src/client/java/net/minecraft/src/forge/MinecraftForgeClient.java
@@ -6,6 +6,7 @@ package net.minecraft.src.forge;
 import net.fabricmc.api.*;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.*;
+import org.jetbrains.annotations.ApiStatus;
 import org.lwjgl.opengl.GL11;
 
 import static org.lwjgl.opengl.GL11.*;
@@ -17,14 +18,20 @@ import static org.lwjgl.opengl.GL11.*;
  */
 @Environment(EnvType.CLIENT)
 public class MinecraftForgeClient {
+	private MinecraftForgeClient() {
+	}
+
 	/**
 	 * Re-initializes the tessellator and binds a custom texture before rendering a block
 	 * that implements {@link ITextureProvider}.
 	 *
+	 * @param block    the block being rendered
+	 * @param renderer the block renderer instance
 	 * @author Space Toad
 	 * @author halotroop2288
 	 * @since 1.0.0
 	 */
+	@ApiStatus.Internal
 	public static void beforeBlockRender(Block block, RenderBlocks renderer) {
 		if (block instanceof ITextureProvider && renderer.overrideBlockTexture == -1) {
 			Tessellator tessellator = Tessellator.instance;
@@ -40,10 +47,13 @@ public class MinecraftForgeClient {
 	 * Re-initializes the tessellator and binds {@code terrain.png} after rendering a block
 	 * to avoid bugs caused by binding a custom texture from {@link ITextureProvider}.
 	 *
+	 * @param block    the block being rendered
+	 * @param renderer the block renderer instance
 	 * @author Space Toad
 	 * @author halotroop2288
 	 * @since 1.0.0
 	 */
+	@ApiStatus.Internal
 	public static void afterBlockRender(Block block, RenderBlocks renderer) {
 		if (block instanceof ITextureProvider && renderer.overrideBlockTexture == -1) {
 			Tessellator tessellator = Tessellator.instance;

--- a/minecraft/beta/1.7.3/src/client/java/net/minecraftforge/injection/ForgeEffectRenderer.java
+++ b/minecraft/beta/1.7.3/src/client/java/net/minecraftforge/injection/ForgeEffectRenderer.java
@@ -14,6 +14,10 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public interface ForgeEffectRenderer {
 	/**
+	 * Adds the given effect to the {@code effectList} if it is not already present.
+	 *
+	 * @param digEffect the particle to add to the list
+	 * @param block     the block that produced the particle
 	 * @author halotroop2288
 	 * @author FlowerChild
 	 * @author Space Toad

--- a/minecraft/beta/1.7.3/src/main/java/net/minecraft/src/forge/Configuration.java
+++ b/minecraft/beta/1.7.3/src/main/java/net/minecraft/src/forge/Configuration.java
@@ -21,6 +21,31 @@ import java.util.*;
  * @since 1.0.0
  */
 public class Configuration {
+	/**
+	 * No specific category.
+	 *
+	 * @since 1.0.1
+	 * @deprecated use {@link PropertyKind#GENERAL} instead
+	 */
+	@Deprecated
+	public static final int GENERAL_PROPERTY = PropertyKind.GENERAL.ordinal();
+	/**
+	 * The Block category.
+	 *
+	 * @since 1.0.1
+	 * @deprecated use {@link PropertyKind#GENERAL} instead
+	 */
+	@Deprecated
+	public static final int BLOCK_PROPERTY = PropertyKind.BLOCK.ordinal();
+	/**
+	 * The Item category.
+	 *
+	 * @since 1.0.1
+	 * @deprecated use {@link PropertyKind#GENERAL} instead
+	 */
+	@Deprecated
+	public static final int ITEM_PROPERTY = PropertyKind.ITEM.ordinal();
+
 	private boolean[] configBlocks = null;
 
 	private final @NotNull File file;
@@ -105,6 +130,23 @@ public class Configuration {
 	 * @param defaultValue the value to use if the property doesn't already exist
 	 * @return the property associated with the given key, or null if the property couldn't be created.
 	 * @author Space Toad
+	 * @see #getOrCreateIntProperty(String, PropertyKind, int)
+	 * @since 1.0.1
+	 * @deprecated use {@link #getOrCreateIntProperty(String, PropertyKind, int)} instead
+	 */
+	public @Nullable Property getOrCreateIntProperty(@NotNull String key, int kind, int defaultValue) {
+		return getOrCreateIntProperty(key, PropertyKind.values()[kind], defaultValue);
+	}
+
+	/**
+	 * The same as {@link #getOrCreateProperty(String, PropertyKind, String)}
+	 * but for {@link Integer#TYPE int} properties rather than {@link String} properties.
+	 *
+	 * @param key          the key for which to get or create a property
+	 * @param kind         the category to look for the property in
+	 * @param defaultValue the value to use if the property doesn't already exist
+	 * @return the property associated with the given key, or null if the property couldn't be created.
+	 * @author Space Toad
 	 * @since 1.0.0
 	 */
 	public @Nullable Property getOrCreateIntProperty(@NotNull String key, @NotNull PropertyKind kind, int defaultValue) {
@@ -154,20 +196,41 @@ public class Configuration {
 	 * @return the property associated with the given key, or null if the property couldn't be created.
 	 * @author Space Toad
 	 * @since 1.0.0
+	 * @deprecated use {@link #getOrCreateProperty(String, PropertyKind, String)} instead
 	 */
-	public @Nullable Property getOrCreateProperty(@NotNull String key, @NotNull PropertyKind kind, @Nullable String defaultValue) {
+	public @Nullable Property getOrCreateProperty(@NotNull String key, int kind, @Nullable String defaultValue) {
+		return getOrCreateProperty(key, PropertyKind.values()[kind], defaultValue);
+	}
+
+	/**
+	 * Gets or creates a property.<br>
+	 * If the property key is already in the configuration, then it will be used.
+	 * Otherwise, {@code defaultValue} will be used.
+	 *
+	 * @param key          the key for which to get or create a property
+	 * @param kind         the category to look for the property in
+	 * @param defaultValue the value to use if the property doesn't already exist
+	 * @return the property associated with the given key, or null if the property couldn't be created.
+	 * @author Space Toad
+	 * @since 1.0.0
+	 */
+	public @Nullable Property getOrCreateProperty(@NotNull String key, @Nullable PropertyKind kind, @Nullable String defaultValue) {
 		TreeMap<String, Property> source = null;
 
-		switch (kind) {
-			case GENERAL:
-				source = generalProperties;
-				break;
-			case BLOCK:
-				source = blockProperties;
-				break;
-			case ITEM:
-				source = itemProperties;
-				break;
+		if (kind == null) {
+			source = generalProperties;
+		} else {
+			switch (kind) {
+				case GENERAL:
+					source = generalProperties;
+					break;
+				case BLOCK:
+					source = blockProperties;
+					break;
+				case ITEM:
+					source = itemProperties;
+					break;
+			}
 		}
 
 		if (source.containsKey(key)) {
@@ -345,19 +408,23 @@ public class Configuration {
 	public static class Property {
 		/**
 		 * The name of the configuration property.
+		 * @since 1.0.0
 		 */
 		public String name;
 		/**
 		 * The value associated with the configuration property.
+		 * @since 1.0.0
 		 */
 		public String value;
 		/**
 		 * The comment that describes the configuration property to the user.
+		 * @since 1.0.0
 		 */
 		public String comment;
 
 		/**
 		 * Default constructor.
+		 * @since 1.0.0
 		 */
 		public Property() {
 		}

--- a/minecraft/beta/1.7.3/src/main/java/net/minecraft/src/forge/Property.java
+++ b/minecraft/beta/1.7.3/src/main/java/net/minecraft/src/forge/Property.java
@@ -1,0 +1,19 @@
+/*
+ * This software is provided under the terms of the Minecraft Forge Public License v1.1.
+ */
+package net.minecraft.src.forge;
+
+/**
+ * @author Space Toad
+ * @since 1.0.1
+ * @deprecated use {@link Configuration.Property} instead.
+ */
+@Deprecated
+public class Property extends Configuration.Property {
+	/**
+	 * Default constructor.
+	 * @since 1.0.1
+	 */
+	public Property() {
+	}
+}


### PR DESCRIPTION
This version was mainly aimed at fixing Java 7 support and removing one feature because it was redundant at the time. I've chosen to ignore both of those things, as this project targets Java 8 at a minimum and does not use ModLoader.

Instead, I've focused on these changes:
- Added support for Ornithe, Babric, and no-intermediary Fabric.
- Fixed JavaDoc and other parts of the buildscript
- Bumped Fabric Loader to 0.16.2

# SourceForge Tickets Ignored

14. [remove custom biome generation](https://sourceforge.net/p/minecraftforge/tickets/14)